### PR TITLE
enable http2 and ssl in all comms in dev mode.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.2")
-addSbtPlugin("com.lightbend.akka.grpc" % "akka-grpc-sbt-plugin" % "df55518c")
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-SNAPSHOT")
+addSbtPlugin("com.lightbend.akka.grpc" % "akka-grpc-sbt-plugin" % "3a71090a")


### PR DESCRIPTION
Needs https://github.com/ignasi35/lagom/commit/12bbd8a99947cfe3858235336635284c507d8cef.

This is a PoC over a lagom service that uses an `akka-grpc` client. This PoC aims to use HTTPS in all communications managed by Lagom (service locator/gateway, gateway-to-service, etc...)